### PR TITLE
Implement changelog.xml file generator

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -30,6 +30,8 @@ var (
 	// MigrationTemplate for the migration generator.
 	//go:embed templates/migration.xml.tmpl
 	migrationTemplate string
+	//go:embed templates/changelog.xml.tmpl
+	changelogTemplate string
 )
 
 var (
@@ -78,6 +80,16 @@ func (g Generator) Generate(ctx context.Context, root string, args []string) err
 		return ErrNameArgMissing
 	}
 
+	if args[2] == "changelog" {
+		err := g.generateChangelogFile()
+		if err != nil {
+			log.Infof("failed generating changelog.xml file: %v", err.Error())
+		}
+
+		log.Infof("changelog.xml file was generated successfully")
+		return nil
+	}
+
 	path, err := g.generateFile(args)
 	if err != nil {
 		return err
@@ -100,7 +112,7 @@ func (g Generator) Generate(ctx context.Context, root string, args []string) err
 		return err
 	}
 
-	log.Infof("migration added to the changelog")
+	log.Infof("migration added to the changelog.xml file")
 	return nil
 }
 
@@ -185,6 +197,18 @@ func (g Generator) generateFile(args []string) (string, error) {
 	}
 
 	return path, ioutil.WriteFile(path, tpl.Bytes(), 0655)
+}
+
+func (g Generator) generateChangelogFile() error {
+	filename := "changelog.xml"
+	path := filepath.Join(g.baseFolder, filename)
+
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, []byte(changelogTemplate), 0655)
 }
 
 // composeFilename from the passed arg and timestamp, if the passed path is

--- a/generator_test.go
+++ b/generator_test.go
@@ -31,10 +31,11 @@ func TestGeneratorRun(t *testing.T) {
 			t.Errorf("error should be nil, got %v", err)
 		}
 
+		// Check generated migration file
 		path := filepath.Join(root, "12345-aaa.xml")
 		_, err = os.Stat(path)
 		if os.IsNotExist(err) {
-			t.Error("should have created the file in the root")
+			t.Error("should have created migration file in the root")
 		}
 
 		d, err := ioutil.ReadFile(path)
@@ -44,6 +45,22 @@ func TestGeneratorRun(t *testing.T) {
 
 		if content := string(d); !strings.Contains(content, "12345-aaa") {
 			t.Errorf("file content %v should contain %v", content, "12345-aaa")
+		}
+
+		// Check that the changelog file exists and verify content
+		path = filepath.Join(root, "migrations", "changelog.xml")
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Error("should have created changelog file in the root")
+		}
+
+		d, err = ioutil.ReadFile(path)
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		if content := string(d); !strings.Contains(content, `<include file="12345-aaa.xml" />`) {
+			t.Errorf("file content %v should contain %v", content, `<include file="12345-aaa.xml" />`)
 		}
 	})
 
@@ -60,6 +77,7 @@ func TestGeneratorRun(t *testing.T) {
 			t.Errorf("error should be nil, got %v", err)
 		}
 
+		// Check generated migration file
 		path := filepath.Join(root, "folder", "is", "here", "12345-aaa.xml")
 		_, err = os.Stat(path)
 		if os.IsNotExist(err) {
@@ -73,6 +91,22 @@ func TestGeneratorRun(t *testing.T) {
 
 		if content := string(d); !strings.Contains(content, "12345-aaa") {
 			t.Errorf("file content %v should contain %v", content, "12345-aaa")
+		}
+
+		// Check that the changelog file exists and verify content
+		path = filepath.Join(root, "migrations", "changelog.xml")
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Error("should have created changelog file in the root")
+		}
+
+		d, err = ioutil.ReadFile(path)
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		if content := string(d); !strings.Contains(content, `<include file="folder/is/here/12345-aaa.xml" />`) {
+			t.Errorf("file content %v should contain %v", content, `<include file="folder/is/here/12345-aaa.xml" />`)
 		}
 	})
 
@@ -94,6 +128,7 @@ func TestGeneratorRun(t *testing.T) {
 			t.Errorf("error should be nil, got %v", err)
 		}
 
+		// Check generated migration file
 		path := filepath.Join(root, "folder", "is", "here", "12345-aaa.xml")
 		_, err = os.Stat(path)
 		if os.IsNotExist(err) {
@@ -107,6 +142,22 @@ func TestGeneratorRun(t *testing.T) {
 
 		if content := string(d); !strings.Contains(content, "12345-aaa") {
 			t.Errorf("file content %v should contain %v", content, "12345-aaa")
+		}
+
+		// Check that the changelog file exists and verify content
+		path = filepath.Join(root, "migrations", "changelog.xml")
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Error("should have created changelog file in the root")
+		}
+
+		d, err = ioutil.ReadFile(path)
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		if content := string(d); !strings.Contains(content, `<include file="folder/is/here/12345-aaa.xml" />`) {
+			t.Errorf("file content %v should contain %v", content, `<include file="folder/is/here/12345-aaa.xml" />`)
 		}
 	})
 
@@ -132,6 +183,7 @@ func TestGeneratorRun(t *testing.T) {
 			t.Errorf("error should be nil, got %v", err)
 		}
 
+		// Check generated migration file
 		path := filepath.Join(root, "migrations", "12345-aaa.xml")
 		_, err = os.Stat(path)
 		if os.IsNotExist(err) {
@@ -146,38 +198,21 @@ func TestGeneratorRun(t *testing.T) {
 		if content := string(d); !strings.Contains(content, "12345-aaa") {
 			t.Errorf("file content %v should contain %v", content, "12345-aaa")
 		}
-	})
 
-	t.Run("changelog generator", func(t *testing.T) {
-		root := t.TempDir()
-		err := os.Chdir(root)
-		if err != nil {
-			t.Error("could not change to temp directory")
-		}
-
-		g := Generator{baseFolder: "migrations"}
-		err = g.Generate(context.Background(), root, []string{"generate", "migration", "changelog"})
-		if err != nil {
-			t.Errorf("error should be nil, got %v", err)
-		}
-
-		path := filepath.Join(root, "migrations", "changelog.xml")
+		// Check that the changelog file exists and verify content
+		path = filepath.Join(root, "migrations", "changelog.xml")
 		_, err = os.Stat(path)
 		if os.IsNotExist(err) {
-			t.Error("should have created the file in the root")
+			t.Error("should have created changelog file in the root")
 		}
 
-		d, err := ioutil.ReadFile(path)
+		d, err = ioutil.ReadFile(path)
 		if err != nil {
 			t.Errorf("error should be nil, got %v", err)
 		}
 
-		if content := string(d); !strings.Contains(content, "<?xml") {
-			t.Errorf("file content %v should contain %v", content, "<?xml")
-		}
-
-		if content := string(d); !strings.Contains(content, "<databaseChangeLog") {
-			t.Errorf("file content %v should contain %v", content, "<databaseChangeLog")
+		if content := string(d); !strings.Contains(content, `<include file="migrations/12345-aaa.xml" />`) {
+			t.Errorf("file content %v should contain %v", content, `<include file="migrations/12345-aaa.xml" />`)
 		}
 	})
 }
@@ -307,18 +342,6 @@ func TestAddToChangelogInvalidFormats(t *testing.T) {
 		if strings.Contains(string(content), `<include file="some.xml" />`) {
 			t.Error("should not contain new statement")
 		}
-	}
-}
-
-func TestAddToChangelogFileNotExists(t *testing.T) {
-	g := Generator{}
-	base := os.TempDir()
-	os.Chdir(base)
-
-	os.Remove(filepath.Join(base, "migrations", "changelog.xml"))
-	err := g.addToChangelog(base, "some.xml")
-	if !os.IsNotExist(err) {
-		t.Errorf("has error, but from unexpected type: %v", err.Error())
 	}
 }
 

--- a/generator_test.go
+++ b/generator_test.go
@@ -147,6 +147,39 @@ func TestGeneratorRun(t *testing.T) {
 			t.Errorf("file content %v should contain %v", content, "12345-aaa")
 		}
 	})
+
+	t.Run("changelog generator", func(t *testing.T) {
+		root := t.TempDir()
+		err := os.Chdir(root)
+		if err != nil {
+			t.Error("could not change to temp directory")
+		}
+
+		g := Generator{baseFolder: "migrations"}
+		err = g.Generate(context.Background(), root, []string{"generate", "migration", "changelog"})
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		path := filepath.Join(root, "migrations", "changelog.xml")
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Error("should have created the file in the root")
+		}
+
+		d, err := ioutil.ReadFile(path)
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		if content := string(d); !strings.Contains(content, "<?xml") {
+			t.Errorf("file content %v should contain %v", content, "<?xml")
+		}
+
+		if content := string(d); !strings.Contains(content, "<databaseChangeLog") {
+			t.Errorf("file content %v should contain %v", content, "<databaseChangeLog")
+		}
+	})
 }
 
 func TestGeneratorComposeName(t *testing.T) {

--- a/templates/changelog.xml.tmpl
+++ b/templates/changelog.xml.tmpl
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+</databaseChangeLog>


### PR DESCRIPTION
Issue #5 
When generating migration files, if the `changelog.xml` file does not exist, then it will create it in the `migrations/` folder.
The log will now tell if this was done.
